### PR TITLE
Add option for fahrenheit

### DIFF
--- a/js/weather.js
+++ b/js/weather.js
@@ -8,7 +8,10 @@ weather.temperature = {
     unit: 'celsius',
 };
 
-const KELVIN = 273;
+// Change to 'F' for Fahrenheit
+var tempUnit = 'C';
+
+const KELVIN = 273.15;
 // Use your own key for the Weather, Get it here: https://openweathermap.org/
 const key = 'aa5b0a76dfbf87441928fb3cc32d3d68';
 
@@ -36,7 +39,8 @@ function getWeather(latitude, longitude) {
             return data;
         })
         .then(function (data) {
-            weather.temperature.value = Math.floor(data.main.temp - KELVIN);
+            let celsius = Math.floor(data.main.temp - KELVIN);
+            weather.temperature.value = (tempUnit == 'C') ? celsius : (celsius * 9/5) + 32;
             weather.description = data.weather[0].description;
             weather.iconId = data.weather[0].icon;
         })
@@ -48,6 +52,6 @@ function getWeather(latitude, longitude) {
 // Display Weather info
 function displayWeather() {
     iconElement.innerHTML = `<img src="icons/${weather.iconId}.png"/>`;
-    tempElement.innerHTML = `${weather.temperature.value}°<span>C</span>`;
+    tempElement.innerHTML = `${weather.temperature.value}°<span>${tempUnit}</span>`;
     descElement.innerHTML = weather.description;
 }


### PR DESCRIPTION
Adds the customization option to set the temperature to Fahrenheit instead of Celsius. The way it's written the `tempUnit` can be set to anything besides `C` and it will switch the value, but the text of `tempUnit` is used for the display so it will be seen. I can update this to more strictly set `C` or `F` if you think that would be better.

This also updates the Kelvin value very slightly.

Discussed in this Issue: https://github.com/MiguelRAvila/Bento/issues/1

<details>
<summary>Screenshots</summary>

* Celsius
![bento_C](https://user-images.githubusercontent.com/22462157/90967650-e3c17800-e4a7-11ea-9b56-2cea1ece480e.png)

* Fahrenheit
![bento_F](https://user-images.githubusercontent.com/22462157/90967651-e7ed9580-e4a7-11ea-9224-a3bc41434688.png)
