### PR TITLE
Correct html element names

### DIFF
--- a/assets/js/weather.js
+++ b/assets/js/weather.js
@@ -2,12 +2,12 @@
 // │││├┤ ├─┤ │ ├─┤├┤ ├┬┘
 // └┴┘└─┘┴ ┴ ┴ ┴ ┴└─┘┴└─
 
-const iconElement = document.querySelector('.weather-icon');
+const iconElement = document.querySelector('.weatherIcon');
 const tempElement = document.querySelector(
-  '.temperature-value p'
+  '.weatherValue p'
 );
 const descElement = document.querySelector(
-  '.temperature-description p'
+  '.weatherDescription p'
 );
 
 // App data


### PR DESCRIPTION
Due to wrong element names the weather section currently isn't working correctly.
I corrected the values that the querySelector needed for the weather to work correctly. 