### PR TITLE
Adding functionality for dark and light theme to auto change

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -46,3 +46,23 @@ themeToggle.addEventListener('click', () => {
 if (CONFIG.imageBackground) {
   document.body.classList.add('withImageBackground');
 }
+
+//Theme switcher based on system dark or light theme (uncomment to activate)
+/*
+if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+  enableDark();
+} else {
+  disableDark();
+}
+*/
+
+//Theme Switcher based on time (uncomment to activate)
+/*
+var d = new Date();
+var hours = d.getHours();
+if (hours >= 18 || hours <= 5) {
+  enableDark();
+} else {
+  disableDark();
+}
+*/


### PR DESCRIPTION
Adds functionality for dark and light theme to auto change based on time (6:00 pm and 5:00 am), and functionality to change based on system theme. Note, for the system theme, this was only tested on mac os. I'm not super well versed in Javascript, so I'm not entirely sure if it will work in other operating systems as well.