### PR TITLE
Close unterminated string literal in config.js

### DIFF
--- a/config.js
+++ b/config.js
@@ -222,7 +222,7 @@ const CONFIG = {
         },
         {
           name: 'Repos',
-          link: 'https://github.com/migueravila,
+          link: 'https://github.com/migueravila',
         },
       ],
     },


### PR DESCRIPTION
Line 225 in `config.js` was missing a closing `'`,preventing the app from rendering properly (including the [live preview](https://migueravila.github.io/Bento/) in the `master` branch).

Closing the string seems to fix all the errors and the page now renders perfectly 😃 