### PR TITLE
Improve docs on usage as new tab on Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 You can use different Add-ons/Extensions for it
 
-- If you use Firefox: [Custom New Tab Page](https://addons.mozilla.org/en-US/firefox/addon/custom-new-tab-page/?src=search)
+- If you use Firefox: [Custom New Tab Page](https://addons.mozilla.org/en-US/firefox/addon/custom-new-tab-page/?src=search) and make sure you enable "Force links to open in the top frame (experimental)" in the extension's prefereces page.
 - If you use Chromium (Brave, Vivaldi, Chrome): [Custom New Tab URL](https://chrome.google.com/webstore/detail/custom-new-tab-url/mmjbdbjnoablegbkcklggeknkfcjkjia)
 
 ## 🎨 Customization


### PR DESCRIPTION
This PR intends to improve documentation on how to use Bento as the new tab page on Firefox, through the extension Custom New Tab Page. An additional setting must toggled on to make external links work properly, that being "Force links to open in the top frame (experimental)". If that is not enabled, some websites refuse to connect.

I didn't include a screenshot of the extension's preferences page to preserve the current aesthetic of the README file, but I can do so it if you think it will helpful for users (perhaps as a hyperlink, to avoid messing up the looks?).

Thanks for developing Bento!