### PR TITLE
Typo in config.js: Autochabge > Autochange

### DIFF
--- a/config.js
+++ b/config.js
@@ -38,7 +38,7 @@ const CONFIG = {
   // Autochange
   autoChangeTheme: true,
 
-  // Autochabge by OS
+  // Autochange by OS
   changeThemeByOS: true,
 
   // Autochange by hour options (24hrs format, string must be in: hh:mm)


### PR DESCRIPTION
Noticed this while configuring. Couldn't see any others in the config file.