### PR TITLE
🔧 Added customizable background image

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ To change the default name, the greetings and if you want to have an image backg
  // General
   name: 'John',
   imageBackground: false,
+  imageUrl: './assets/background.jpg', // Set custom background image URL. If the page is served insecurely, you may have issues loading images from pages over https.
   openInNewTab: true,
 
   // Greetings
@@ -94,7 +95,7 @@ To change the default name, the greetings and if you want to have an image backg
 
 ```
 
-> You can change the background by substituting the `background.jpg` file in `assets` folder.
+> You can change the background by providing a link to an image in `config.js`.
 
 ![](assets/img/backgroundImage.png)
 

--- a/app.css
+++ b/app.css
@@ -30,7 +30,6 @@
   --cards: #e4e6e6; /* Cards color */
 
   /* Image background  */
-  --imgbg: url(assets/background.jpg); /* Image URL */
   --imgcol: linear-gradient(
     rgba(255, 255, 255, 0.7),
     rgba(255, 255, 255, 0.7)

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -39,6 +39,8 @@ themeToggle.addEventListener('click', () => {
 });
 
 if (CONFIG.imageBackground) {
+	const root = document.querySelector(':root');
+	root.style.setProperty('--imgbg', `url(${CONFIG.imageUrl})`);
 	document.body.classList.add('withImageBackground');
 }
 

--- a/config.js
+++ b/config.js
@@ -13,6 +13,7 @@ const CONFIG = {
 	// General
 	name: 'John',
 	imageBackground: false,
+	imageUrl: './assets/background.jpg', // Set custom background image URL. If the page is served insecurely, you may have issues loading images from pages over https.
 	openInNewTab: true,
 	twelveHourFormat: false,
 


### PR DESCRIPTION
#  🔧 Customizable background images

 - Configurable through config.js, this just sets the CSS variable to the provided URL. 
 - Defaults to ./assets/background.jpg. 
 - Updated README docs.

Again, this is more for convenience when running in docker as it's not as easy to just swap the file.

Btw, if any of these are outside of the scope of this, please let me know! I'll keep these in my own fork and maintain a separate docker image :)