### PR TITLE
Fix the upper limit for greetingNight

### DIFF
--- a/assets/js/greeting.js
+++ b/assets/js/greeting.js
@@ -12,7 +12,7 @@ const gree2 = `${CONFIG.greetingMorning}\xa0`;
 const gree3 = `${CONFIG.greetingAfternoon}\xa0`;
 const gree4 = `${CONFIG.greetingEvening}\xa0`;
 
-if (hour >= 23 || hour < 5) {
+if (hour >= 23 || hour < 6) {
 	document.getElementById('greetings').innerText = gree1 + name;
 } else if (hour >= 6 && hour < 12) {
 	document.getElementById('greetings').innerText = gree2 + name;


### PR DESCRIPTION
It's set to < 5, and greetingMorning to >= 6. So between 5 and 6am, the else clause wins and Bento says "Good evening, John!".

Here's a screenshot of the issue:

![Screenshot from 2022-12-09 05-14-19](https://user-images.githubusercontent.com/43856183/206782080-c3f63171-dd17-4a3f-9cf5-d6181d376401.png)
