### PR TITLE
Added option to local store last weather data fetched

### DIFF
--- a/assets/js/weather.js
+++ b/assets/js/weather.js
@@ -7,12 +7,35 @@ const iconElement = document.querySelector('.weatherIcon');
 const tempElement = document.querySelector('.weatherValue p');
 const descElement = document.querySelector('.weatherDescription p');
 
+let loadLastWeather = CONFIG.showLastWeather;
+let lastTemperature = localStorage.getItem('lastTemperature');
+let lastTempDescription = localStorage.getItem('lastWeatherDescription');
+let lastWeatherIcon = localStorage.getItem('lastWeatherIcon');
+
 const weather = {};
 weather.temperature = {
 	unit: 'celsius',
 };
 
-var tempUnit = CONFIG.weatherUnit;
+let tempUnit = CONFIG.weatherUnit;
+
+function storeWeather(temperature, description, icon) {
+	localStorage.setItem('lastTemperature', temperature.toFixed(0));
+	localStorage.setItem('lastWeatherDescription', description);
+	localStorage.setItem('lastWeatherIcon', icon);
+}
+
+function showLastWeather() {
+	iconElement.innerHTML = `<img src="assets/icons/${CONFIG.weatherIcons}/${localStorage.getItem('lastWeatherIcon')}.png"/>`;
+	tempElement.innerHTML = `${localStorage.getItem('lastTemperature')}°<span class="darkfg">${tempUnit}</span>`;
+	descElement.innerHTML = localStorage.getItem('lastWeatherDescription');
+}
+
+if (loadLastWeather && lastTemperature) {
+	showLastWeather()
+} else {
+	iconElement.innerHTML = `<img src="assets/icons/${CONFIG.weatherIcons}/unknown.png"/>`;
+}
 
 const KELVIN = 273.15;
 const key = `${CONFIG.weatherKey}`;
@@ -49,6 +72,11 @@ function getWeather(latitude, longitude) {
 			weather.temperature.value = tempUnit == 'C' ? celsius : (celsius * 9) / 5 + 32;
 			weather.description = data.weather[0].description;
 			weather.iconId = data.weather[0].icon;
+
+			if (loadLastWeather) {
+				storeWeather(data.main.temp - KELVIN, data.weather[0].description, data.weather[0].icon)
+			}
+
 		})
 		.then(function() {
 			displayWeather();

--- a/config.js
+++ b/config.js
@@ -27,6 +27,7 @@ const CONFIG = {
 
 	// Weather
 	weatherKey: 'InsertYourAPIKeyHere123456', // Write here your API Key
+	showLastWeather: true, // Show last weather registered in localStore while actual data is being fetched
 	weatherIcons: 'OneDark', // 'Onedark', 'Nord', 'Dark', 'White'
 	weatherUnit: 'C', // 'F', 'C'
 	language: 'en', // More languages in https://openweathermap.org/current#multi


### PR DESCRIPTION
It saves your last fetched weather data to LocalStorage. Next time you open the browser it will show you that information while it fetchs the new one.
It is a great option if you open and close the browser several times per session. 